### PR TITLE
Upgrade to Telegraf 0.1.4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ansible-playbook-telegraf
 #
-telegraf_version: 0.1.2
+telegraf_version: 0.1.4
 influxdb_url: http://localhost:8086
 influxdb_database: testdb
 influxdb_user: someuser


### PR DESCRIPTION
Which includes a fix for installing Telegraf and InfluxDB on the same
machine: influxdb/telegraf#50

We're separately upgrading our usage in: alphagov/tsuru-ansible#122

---

I'm not sure why this playbook specifies a version and our InfluxDB playbook uses `latest`?

This will force a rebase of #2
