### PR TITLE
[#98748824] Fix broken template installation path

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,6 @@
   service: name=telegraf enabled=yes state=started
 
 - name: Generate telegraf config from template
-  template: src=telegraf.conf.j2 dest=/etc/opt/influxdb/telegraf.conf
+  template: src=telegraf.conf.j2 dest=/etc/opt/telegraf/telegraf.conf
   notify:
     - restart telegraf


### PR DESCRIPTION
**What**

Fix ansible reporting that `/etc/opt/influxdb` directory no longer exists.

**Problem**

Influxdb upstream has changed the path to the `telegraf` configuration
file from `/etc/opt/influxdb/` to `/etc/opt/telegraf`

**How to test this PR**

You can validate this PR by starting a vagrant box:

```
vagrant up
```

**Who should review this PR**
- Anyone who thinks that the cup is half full
