### PR TITLE
Add influxdb_tags token to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ influxdb_pass: somepassword
 
 You will want to override these role variables within your playbooks.
 
+You can associate tags with the server and they will be recognised by influxdb and grafana. Example:
+
+```
+influxdb_tags:
+	role: web-server
+	region: eu-west
+```
+
 ### Usage
 
 ```

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -39,8 +39,8 @@ password = "{{ influxdb_pass }}"
 
 # Tags can also be specified via a normal map, but only one form at a time:
 
-# [influxdb.tags]
-# dc = "us-east-1"
+[influxdb.tags]
+{{ influxdb_tags }}
 
 # Configuration for telegraf itself
 # [agent]

--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -40,7 +40,11 @@ password = "{{ influxdb_pass }}"
 # Tags can also be specified via a normal map, but only one form at a time:
 
 [influxdb.tags]
-{{ influxdb_tags }}
+{% if influxdb_tags is defined %}
+{% for tag_name, value in influxdb_tags.iteritems() %}
+{{ tag_name }} = "{{ value }}"
+{% endfor %}
+{% endif %}
 
 # Configuration for telegraf itself
 # [agent]


### PR DESCRIPTION
**What**

AWS does not give us meaningful host names inside the VMs (it gives us names of the form ip-10-10-10-10 instead), which is not very helpful for metric collection.

Telegraf supports passing extra tags with the metric data which we can use inside Grafana to define dashboards.

This PR enables the `[influxdb.tags]` stanza inside the telegraf.conf and provides us with a `{{ influxdb_tags }}` templating point where we can inject extra tag values using Ansible (or some other script).

**How this PR should be reviewed**

This PR should reviewed in the following context:
- I need to be able to pass extra tags to Telegraf for use during metric collection.

**How to test this PR**

If you do not specify any `{{ influxdb_tags }}`, everything will continue to work as before - tags are optional.
If you specify tags, they must be of the form `tag_name="some_stuff"` - You will see the tags available in the metrics dropdowns in Grafana

 **Who should review this PR**
- Anyone in the core team except @saliceti  and myself

**Notes**

This will be somewhat tricky to test until we've made the changes to our tsusu-ansible repository to populate the `{{ influxdb_tags }}` fields, but we cannot make those changes until after this has been merged.
