### PR TITLE
[#106191568] New config template for telegraf 0.2.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,12 @@
 - name: start telegraf service and ensure that it is enabled
   service: name=telegraf enabled=yes state=started
 
+- set_fact: config_template="telegraf.conf.j2"
+
+- set_fact: config_template="telegraf.conf-0.2.0.j2"
+  when: "{{ telegraf_version | version_compare('0.2.0', '>=') }}"
+
 - name: Generate telegraf config from template
-  template: src=telegraf.conf.j2 dest=/etc/opt/telegraf/telegraf.conf
+  template: src="{{ config_template }}" dest=/etc/opt/telegraf/telegraf.conf
   notify:
     - restart telegraf

--- a/templates/telegraf.conf-0.2.0.j2
+++ b/templates/telegraf.conf-0.2.0.j2
@@ -1,0 +1,112 @@
+# Telegraf configuration
+
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared plugins.
+
+# Even if a plugin has no configuration, it must be declared in here
+# to be active. Declaring a plugin means just specifying the name
+# as a section with no variables. To deactivate a plugin, comment
+# out the name and any variables.
+
+# Use 'telegraf -config telegraf.toml -test' to see what metrics a config
+# file would generate.
+
+# One rule that plugins conform to is wherever a connection string
+# can be passed, the values '' and 'localhost' are treated specially.
+# They indicate to the plugin to use their own builtin configuration to
+# connect to the local system.
+
+# NOTE: The configuration has a few required parameters. They are marked
+# with 'required'. Be sure to edit those to make this configuration work.
+
+# Tags can also be specified via a normal map, but only one form at a time:
+[tags]
+{% if influxdb_tags is defined %}
+{% for tag_name, value in influxdb_tags.iteritems() %}
+{{ tag_name }} = "{{ value }}"
+{% endfor %}
+{% endif %}
+
+# Configuration for telegraf agent
+[agent]
+  # Default data collection interval for all plugins
+  interval = "10s"
+  # Rounds collection interval to 'interval'
+  # ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  # Default data flushing interval for all outputs
+  flush_interval = "10s"
+  # Jitter the flush interval by a random range
+  # ie, a jitter of 5s and interval 10s means flush will happen every 10-15s
+  flush_jitter = "5s"
+  # Number of times to retry each data flush
+  flush_retries = 2
+
+  # Run telegraf in debug mode
+  debug = false
+  # Override default hostname, if empty use os.Hostname()
+  hostname = ""
+
+
+###############################################################################
+#                                  OUTPUTS                                    #
+###############################################################################
+
+[outputs]
+
+# Configuration for influxdb server to send metrics to
+[outputs.influxdb]
+  # The full HTTP endpoint URL for your InfluxDB instance
+  # Multiple urls can be specified for InfluxDB cluster support. Server to
+  # write to will be randomly chosen each interval.
+  urls = ["{{ influxdb_url }}"] # required.
+  # The target database for metrics. This database must already exist
+  database = "influxdb" # required.
+  # Precision of writes, valid values are n, u, ms, s, m, and h
+  # note: using second precision greatly helps InfluxDB compression
+  precision = "s"
+
+  # Connection timeout (for the connection with InfluxDB), formatted as a string.
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  # If not provided, will default to 0 (no timeout)
+  # timeout = "5s"
+  username = "{{ influxdb_user }}"
+  password = "{{ influxdb_pass }}"
+
+  # Set the user agent for the POSTs (can be useful for log differentiation)
+  # user_agent = "telegraf"
+
+
+###############################################################################
+#                                  PLUGINS                                    #
+###############################################################################
+
+# Read metrics about cpu usage
+[cpu]
+  # Whether to report per-cpu stats or not
+  percpu = true
+  # Whether to report total system cpu stats or not
+  totalcpu = true
+  # Comment this line if you want the raw CPU time metrics
+  drop = ["cpu_time"]
+
+# Read metrics about disk usage by mount point
+[disk]
+  # no configuration
+
+# Read metrics about disk IO by device
+[io]
+  # no configuration
+
+# Read metrics about memory usage
+[mem]
+  # no configuration
+
+# Read metrics about swap memory usage
+[swap]
+  # no configuration
+
+# Read metrics about system load & uptime
+[system]
+  # no configuration


### PR DESCRIPTION
[#106191568 Monitoring dashboard for the trial Tsuru platform](https://www.pivotaltracker.com/story/show/106191568)
# What

For the monitoring dashboard for tsuru, we decided to upgrade telegraf to 0.2.0.
# Context

To support 0.2.0, as the configuration format changes, we added a new template which will be used if the version is new.
# How to test this?

Update the version in `site.yml` to add the variable `telegraf_version: 0.2.0` and do: `vagrant up`:

```

---
- hosts: all
  sudo: yes
  vars:
     telegraf_version: 0.2.0
  roles:
    - .
```
# After review

Please update the release as a final release.
# Who can review this?

Anyone but @keymon @saliceti or @combor 
